### PR TITLE
Scripts download data

### DIFF
--- a/analysis/diabetes_analysis.ipynb
+++ b/analysis/diabetes_analysis.ipynb
@@ -2095,9 +2095,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:diabetes_predictor-diabetes_predictor]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-diabetes_predictor-diabetes_predictor-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -69,7 +69,7 @@ def read_zip(url, directory):
 
 @click.command()
 @click.option('--url', type=str, help="URL of dataset to be downloaded")
-@click.option('--write_to', type=str, help="Path to directory where raw data will be written to")
+@click.option('--write-to', type=str, help="Path to directory where raw data will be written to")
 def main(url, write_to):
     """Downloads data zip data from the web to a local filepath and extracts it."""
     try:

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -30,10 +30,10 @@ def read_zip(url, directory):
     if request.status_code != 200:
         raise ValueError('The URL provided does not exist.')
     
-    # check if the URL points to a zip file, if not raise an error  
-    #if request.headers['content-type'] != 'application/zip':
-    if filename_from_url[-4:] != '.zip':
-        raise ValueError('The URL provided does not point to a zip file.')
+    # # check if the URL points to a zip file, if not raise an error  
+    # #if request.headers['content-type'] != 'application/zip':
+    # if filename_from_url[-4:] != '.zip':
+    #     raise ValueError('The URL provided does not point to a zip file.')
     
     # check if the directory exists, if not raise an error
     if not os.path.isdir(directory):

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -1,0 +1,82 @@
+# download_data.py
+# author: Jenny Zhang
+# date: 2024-12-03
+
+import click
+import os
+import zipfile
+import requests
+
+
+def read_zip(url, directory):
+    """
+    Read a zip file from the given URL and extract its contents to the specified directory.
+
+    Parameters:
+    ----------
+    url : str
+        The URL of the zip file to be read.
+    directory : str
+        The directory where the contents of the zip file will be extracted.
+
+    Returns:
+    -------
+    None
+    """
+    request = requests.get(url)
+    filename_from_url = os.path.basename(url)
+
+    # check if URL exists, if not raise an error
+    if request.status_code != 200:
+        raise ValueError('The URL provided does not exist.')
+    
+    # check if the URL points to a zip file, if not raise an error  
+    #if request.headers['content-type'] != 'application/zip':
+    if filename_from_url[-4:] != '.zip':
+        raise ValueError('The URL provided does not point to a zip file.')
+    
+    # check if the directory exists, if not raise an error
+    if not os.path.isdir(directory):
+        raise ValueError('The directory provided does not exist.')
+
+    # write the zip file to the directory
+    path_to_zip_file = os.path.join(directory, filename_from_url)
+    with open(path_to_zip_file, 'wb') as f:
+        f.write(request.content)
+
+    # get list of files/directories in the directory
+    original_files = os.listdir(directory)
+    original_timestamps = []
+    for filename in original_files:
+        filename = os.path.join(directory, filename)
+        original_timestamp = os.path.getmtime(filename)
+        original_timestamps.append(original_timestamp)
+
+    # extract the zip file to the directory
+    with zipfile.ZipFile(path_to_zip_file, 'r') as zip_ref:
+        zip_ref.extractall(directory)
+
+    # check if any files were extracted, if not raise an error
+    # get list of files/directories in the directory
+    current_files = os.listdir(directory)
+    current_timestamps = []
+    for filename in current_files:
+        filename = os.path.join(directory, filename)
+        current_timestamp = os.path.getmtime(filename)
+        current_timestamps.append(current_timestamp)
+    if (len(current_files) == len(original_files)) & (original_timestamps == current_timestamps):
+        raise ValueError('The ZIP file is empty.')
+
+@click.command()
+@click.option('--url', type=str, help="URL of dataset to be downloaded")
+@click.option('--write_to', type=str, help="Path to directory where raw data will be written to")
+def main(url, write_to):
+    """Downloads data zip data from the web to a local filepath and extracts it."""
+    try:
+        read_zip(url, write_to)
+    except:
+        os.makedirs(write_to)
+        read_zip(url, write_to)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The `download_data.py` script downloads data from Kaggle as a zipfile and extracts the data from zip file for use. 

It is crucial that we allow for reproducibility of data by accessing data from url than having data load from data folder that we did before. It is noted as part of milestone instruction that the data should load from url.

Note some codes borrowed from Tiff's example.

Run and test the scripts with the following command in terminal:
```
python scripts/download_data.py \
    --url="https://www.kaggle.com/api/v1/datasets/download/uciml/pima-indians-diabetes-database" \
    --write-to=data/raw
```
